### PR TITLE
Format long strings

### DIFF
--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -260,7 +260,12 @@ impl fmt::Display for DiagBuilder2 {
         }
 
         if self.get_severity() == Severity::Bug {
-            write!(f, "\nYou have encountered a compiler bug. Sorry about that! We would appreciate if you open an issue [1] and describe how you triggered the bug, together with a minimal snippet of code to reproduce it. Thanks!\n")?;
+            write!(
+                f,
+                "\nYou have encountered a compiler bug. Sorry about that! We would appreciate if \
+                 you open an issue [1] and describe how you triggered the bug, together with a \
+                 minimal snippet of code to reproduce it. Thanks!\n"
+            )?;
             write!(f, "[1]: https://github.com/fabianschuiki/moore\n")?;
         }
 

--- a/src/derive/visitor.rs
+++ b/src/derive/visitor.rs
@@ -38,15 +38,9 @@ pub(crate) fn visitor(_input: TokenStream) -> TokenStream {
 
     // Generate some documentation.
     let mut doc = format!(
-        "A visitor.\n\n\
-        Use the `accept()` function to start visiting nodes. For example:\n\n\
-        ```ignore\n\
-        struct MagicVisitor;\n\n\
-        impl Visitor for MagicVisitor {{\n\
-        }}\n\n\
-        node.accept(&mut MagicVisitor);\n\
-        ```\n\n\
-        "
+        "A visitor.\n\nUse the `accept()` function to start visiting nodes. For \
+         example:\n\n```ignore\nstruct MagicVisitor;\n\nimpl Visitor for MagicVisitor \
+         {{\n}}\n\nnode.accept(&mut MagicVisitor);\n```\n\n"
     );
     doc.push_str("Implements the visitor pattern over the following nodes:\n\n");
     for call in &calls {
@@ -77,8 +71,8 @@ pub(crate) fn visitor(_input: TokenStream) -> TokenStream {
 
         // Generate some documentation.
         let pre_doc = format!(
-            "Called for every `{}` node before visiting its children.\n\n\
-            Return `false` from this function to not visit the node's children.",
+            "Called for every `{}` node before visiting its children.\n\nReturn `false` from this \
+             function to not visit the node's children.",
             name
         );
         let post_doc = format!(

--- a/src/svlog/hir/lowering.rs
+++ b/src/svlog/hir/lowering.rs
@@ -941,10 +941,15 @@ fn lower_expr<'gcx>(
                 None => size_needed,
             };
             if size_needed > size {
-                cx.emit(DiagBuilder2::warning(format!(
-                    "`{}` is too large",
-                    value,
-                )).span(expr.span).add_note(format!("constant is {} bits wide, but the value `{}{}` needs {} bits to not be truncated", size, base, value, size_needed)));
+                cx.emit(
+                    DiagBuilder2::warning(format!("`{}` is too large", value,))
+                        .span(expr.span)
+                        .add_note(format!(
+                            "constant is {} bits wide, but the value `{}{}` needs {} bits to not \
+                             be truncated",
+                            size, base, value, size_needed
+                        )),
+                );
             }
 
             // Identify the special bits (x and z) in the input.

--- a/src/svlog/port_list.rs
+++ b/src/svlog/port_list.rs
@@ -348,7 +348,10 @@ fn lower_module_ports_ansi<'gcx>(
         cx.emit(
             DiagBuilder2::error("port declaration in body of ANSI-style module")
                 .span(ast.span)
-                .add_note("Modules with an ANSI-style port list cannot have port declarations in the body.")
+                .add_note(
+                    "Modules with an ANSI-style port list cannot have port declarations in the \
+                     body.",
+                )
                 .add_note("Consider using non-ANSI style.")
                 .add_note("First port uses ANSI style:")
                 .span(first_span),
@@ -670,9 +673,8 @@ fn lower_module_ports_nonansi<'gcx>(
                     ))
                     .span(span)
                     .add_note(
-                        "Port already has a net/variable type. \
-                        Cannot declare an additional net/variable with the same \
-                        name.",
+                        "Port already has a net/variable type. Cannot declare an additional \
+                         net/variable with the same name.",
                     )
                     .add_note("Port declaration was here:")
                     .span(port.span),

--- a/src/svlog/port_mapping.rs
+++ b/src/svlog/port_mapping.rs
@@ -91,7 +91,8 @@ pub(crate) fn compute<'gcx>(
                             ))
                             .span(name.span)
                             .add_note(
-                                "The module has unnamed ports which require connecting by position.",
+                                "The module has unnamed ports which require connecting by \
+                                 position.",
                             )
                             .add_note(format!("Remove `.{}(...)`", name)),
                         );

--- a/src/svlog/syntax/parser.rs
+++ b/src/svlog/syntax/parser.rs
@@ -172,7 +172,15 @@ trait AbstractParser<'n> {
                 CloseDelim(x) => {
                     if let Some(open) = stack.pop() {
                         if open != x {
-                            self.add_diag(DiagBuilder2::fatal(format!("found closing `{}` which is not the complement to the previous opening `{}`", CloseDelim(x), OpenDelim(open))).span(sp));
+                            self.add_diag(
+                                DiagBuilder2::fatal(format!(
+                                    "found closing `{}` which is not the complement to the \
+                                     previous opening `{}`",
+                                    CloseDelim(x),
+                                    OpenDelim(open)
+                                ))
+                                .span(sp),
+                            );
                             break;
                         }
                     } else {
@@ -3685,7 +3693,14 @@ fn parse_block<'n>(
         let (name, name_span) = p.eat_ident("block label")?;
         if let Some(before) = *label {
             if before != name {
-                p.add_diag(DiagBuilder2::error(format!("Block label {} at end of block does not match label {} at beginning of block", name, before)).span(name_span));
+                p.add_diag(
+                    DiagBuilder2::error(format!(
+                        "Block label {} at end of block does not match label {} at beginning of \
+                         block",
+                        name, before
+                    ))
+                    .span(name_span),
+                );
             }
         } else {
             p.add_diag(
@@ -4404,7 +4419,14 @@ fn parse_generate_block<'n>(p: &mut dyn AbstractParser<'n>) -> ReportedResult<Ge
         let n = parse_identifier_name(p, "generate block label")?;
         if let Some(existing) = label {
             if existing.value != n.value {
-                p.add_diag(DiagBuilder2::error(format!("Label {} given after generate block does not match label {} given before the block", n, existing)).span(n.span));
+                p.add_diag(
+                    DiagBuilder2::error(format!(
+                        "Label {} given after generate block does not match label {} given before \
+                         the block",
+                        n, existing
+                    ))
+                    .span(n.span),
+                );
                 return Err(());
             }
         } else {

--- a/src/svlog/typeck.rs
+++ b/src/svlog/typeck.rs
@@ -775,9 +775,8 @@ pub(crate) fn need_self_determined_type<'gcx>(
                 DiagBuilder2::error(format!("{} has no self-determined type", desc))
                     .span(cx.span(node_id))
                     .add_note(format!(
-                        "The type of {} must be inferred from \
-                         context, but the location where you used it does not \
-                         provide such information.",
+                        "The type of {} must be inferred from context, but the location where you \
+                         used it does not provide such information.",
                         desc
                     ))
                     .add_note(format!("Try a cast: `T'({})`", extract)),
@@ -1154,8 +1153,8 @@ pub(crate) fn operation_type<'gcx>(
                     DiagBuilder2::error(format!("type of {} cannot be inferred", expr.desc_full()))
                         .span(expr.human_span())
                         .add_note(
-                            "The operand does not have a self-determined type, \
-                             and the type cannot be inferred from the context.",
+                            "The operand does not have a self-determined type, and the type \
+                             cannot be inferred from the context.",
                         )
                         .add_note(format!("Try a cast: `T'({})`", expr.span().extract())),
                 );
@@ -1226,8 +1225,8 @@ pub(crate) fn operation_type<'gcx>(
                     DiagBuilder2::error(format!("type of {} cannot be inferred", expr.desc_full()))
                         .span(expr.human_span())
                         .add_note(
-                            "Neither of the operands has a self-determined type, \
-                             and the type cannot be inferred from the context.",
+                            "Neither of the operands has a self-determined type, and the type \
+                             cannot be inferred from the context.",
                         )
                         .add_note(format!("Try a cast: `T'({})`", expr.span().extract())),
                 );
@@ -1413,9 +1412,8 @@ pub(crate) fn need_type_context<'gcx>(
                 DiagBuilder2::error(format!("type of {} cannot be inferred from context", desc))
                     .span(cx.span(node_id))
                     .add_note(format!(
-                        "The type of {} must be inferred from \
-                         context, but the location where you used it does not \
-                         provide such information.",
+                        "The type of {} must be inferred from context, but the location where you \
+                         used it does not provide such information.",
                         desc
                     ))
                     .add_note(format!("Try a cast: `T'({})`", extract)),

--- a/src/vhdl/hir/type_decl.rs
+++ b/src/vhdl/hir/type_decl.rs
@@ -305,8 +305,8 @@ fn unpack_units<'t>(
                 ))
                 .span(type_name.span)
                 .add_note(
-                    "A physical type must have a primary unit of the form `<name>;`. \
-                         See IEEE 1076-2008 section 5.2.4.",
+                    "A physical type must have a primary unit of the form `<name>;`. See IEEE \
+                     1076-2008 section 5.2.4.",
                 ),
             );
             return Err(());
@@ -321,8 +321,8 @@ fn unpack_units<'t>(
             ))
             .span(n.span)
             .add_note(
-                "A physical type cannot have multiple primary units. \
-                     See IEEE 1076-2008 section 5.2.4.",
+                "A physical type cannot have multiple primary units. See IEEE 1076-2008 section \
+                 5.2.4.",
             ),
         );
         had_fails = true;

--- a/src/vhdl/nodes/seq_stmt.rs
+++ b/src/vhdl/nodes/seq_stmt.rs
@@ -74,9 +74,17 @@ impl<'sbc, 'lazy, 'sb, 'ast, 'ctx> AddContext<'sbc, 'lazy, 'sb, 'ast, 'ctx> {
             ast::NullStmt => self.add_null_stmt(stmt).map(Into::into),
             ref wrong => {
                 self.emit(
-                    DiagBuilder2::error(format!("a {} cannot appear in {}", wrong.desc(), container_name))
+                    DiagBuilder2::error(format!(
+                        "a {} cannot appear in {}",
+                        wrong.desc(),
+                        container_name
+                    ))
                     .span(stmt.human_span())
-                    .add_note(format!("Only sequential statements are allowed in {}. See IEEE 1076-2008 section 10.", container_name))
+                    .add_note(format!(
+                        "Only sequential statements are allowed in {}. See IEEE 1076-2008 section \
+                         10.",
+                        container_name
+                    )),
                 );
                 Err(())
             }
@@ -650,17 +658,21 @@ impl<'sbc, 'lazy, 'sb, 'ast, 'ctx> AddContext<'sbc, 'lazy, 'sb, 'ast, 'ctx> {
             };
             let conds = slice
                 .into_iter()
-                .map(|&ast::CondWave(ref wave, ref cond)|{
-                    match *cond {
-                        Some(ref cond) => Ok((wave, cond)),
-                        None => {
-                            self.emit(
-                                DiagBuilder2::error(format!("`{}` missing a `when` condition", wave.span.extract()))
-                                .span(wave.span)
-                                .add_note("Either all or none of the waveforms or expressions in the assignment can have a `when` condition.")
-                            );
-                            Err(())
-                        }
+                .map(|&ast::CondWave(ref wave, ref cond)| match *cond {
+                    Some(ref cond) => Ok((wave, cond)),
+                    None => {
+                        self.emit(
+                            DiagBuilder2::error(format!(
+                                "`{}` missing a `when` condition",
+                                wave.span.extract()
+                            ))
+                            .span(wave.span)
+                            .add_note(
+                                "Either all or none of the waveforms or expressions in the \
+                                 assignment can have a `when` condition.",
+                            ),
+                        );
+                        Err(())
                     }
                 })
                 .collect::<Vec<Result<_>>>()
@@ -671,8 +683,11 @@ impl<'sbc, 'lazy, 'sb, 'ast, 'ctx> AddContext<'sbc, 'lazy, 'sb, 'ast, 'ctx> {
             if ast.len() != 1 {
                 self.emit(
                     DiagBuilder2::error(format!("more than one waveform or expression"))
-                    .span(ast[0].0.span)
-                    .add_note("An unconditional assignment must have exactly one waveform or expression.")
+                        .span(ast[0].0.span)
+                        .add_note(
+                            "An unconditional assignment must have exactly one waveform or \
+                             expression.",
+                        ),
                 );
                 Err(())
             } else {

--- a/src/vhdl/nodes/type_decl.rs
+++ b/src/vhdl/nodes/type_decl.rs
@@ -82,9 +82,15 @@ impl<'sbc, 'lazy, 'sb, 'ast, 'ctx> AddContext<'sbc, 'lazy, 'sb, 'ast, 'ctx> {
                         Some(u) => u,
                         None => {
                             self.emit(
-                                DiagBuilder2::error(format!("physical type `{}` has no primary unit", name.value))
+                                DiagBuilder2::error(format!(
+                                    "physical type `{}` has no primary unit",
+                                    name.value
+                                ))
                                 .span(name.span)
-                                .add_note("A physical type must have a primary unit of the form `<name>;`. See IEEE 1076-2008 section 5.2.4.")
+                                .add_note(
+                                    "A physical type must have a primary unit of the form \
+                                     `<name>;`. See IEEE 1076-2008 section 5.2.4.",
+                                ),
                             );
                             return Err(());
                         }
@@ -92,9 +98,15 @@ impl<'sbc, 'lazy, 'sb, 'ast, 'ctx> AddContext<'sbc, 'lazy, 'sb, 'ast, 'ctx> {
                     let mut had_fails = false;
                     for (_, n) in prim_iter {
                         self.emit(
-                            DiagBuilder2::error(format!("physical type `{}` has multiple primary units", name.value))
+                            DiagBuilder2::error(format!(
+                                "physical type `{}` has multiple primary units",
+                                name.value
+                            ))
                             .span(n.span)
-                            .add_note("A physical type cannot have multiple primary units. See IEEE 1076-2008 section 5.2.4.")
+                            .add_note(
+                                "A physical type cannot have multiple primary units. See IEEE \
+                                 1076-2008 section 5.2.4.",
+                            ),
                         );
                         had_fails = true;
                     }

--- a/src/vhdl/score/lower_hir.rs
+++ b/src/vhdl/score/lower_hir.rs
@@ -466,8 +466,7 @@ impl<'lazy, 'sb, 'ast, 'ctx> ScoreContext<'lazy, 'sb, 'ast, 'ctx> {
                     ast::ObjKind::SharedVar => {
                         self.emit(
                             DiagBuilder2::error(
-                                "not a variable; shared variables \
-                                may not appear in a package body",
+                                "not a variable; shared variables may not appear in a package body",
                             )
                             .span(decl.human_span()),
                         );
@@ -596,8 +595,8 @@ impl<'lazy, 'sb, 'ast, 'ctx> ScoreContext<'lazy, 'sb, 'ast, 'ctx> {
                         ))
                         .span(stmt.human_span())
                         .add_note(format!(
-                            "Only concurrent statements are allowed \
-                            in {}. See IEEE 1076-2008 section 11.1.",
+                            "Only concurrent statements are allowed in {}. See IEEE 1076-2008 \
+                             section 11.1.",
                             container_name
                         )),
                     );
@@ -890,9 +889,8 @@ impl<'lazy, 'sb, 'ast, 'ctx> ScoreContext<'lazy, 'sb, 'ast, 'ctx> {
                 DiagBuilder2::error(format!("Function `{}` has no return type", name.value))
                     .span(name.span)
                     .add_note(
-                        "Functions require a return type. Use a \
-                        procedure if you want no return type. See \
-                        IEEE 1076-2008 section 4.2.1.",
+                        "Functions require a return type. Use a procedure if you want no return \
+                         type. See IEEE 1076-2008 section 4.2.1.",
                     ),
             );
             return Err(());
@@ -919,8 +917,8 @@ impl<'lazy, 'sb, 'ast, 'ctx> ScoreContext<'lazy, 'sb, 'ast, 'ctx> {
                 DiagBuilder2::error(format!("`{}` is not a valid subprogram name", name.value))
                     .span(name.span)
                     .add_note(
-                        "Bit literals cannot be used as subprogram \
-                        names. See IEEE 1076-2008 section 4.2.1.",
+                        "Bit literals cannot be used as subprogram names. See IEEE 1076-2008 \
+                         section 4.2.1.",
                     ),
             );
             return Err(());
@@ -930,8 +928,8 @@ impl<'lazy, 'sb, 'ast, 'ctx> ScoreContext<'lazy, 'sb, 'ast, 'ctx> {
                 DiagBuilder2::error(format!("`{}` overload must be a function", name.value))
                     .span(name.span)
                     .add_note(
-                        "Procedures cannot overload operators. Use \
-                        a function. See IEEE 1076-2008 section 4.2.1.",
+                        "Procedures cannot overload operators. Use a function. See IEEE 1076-2008 \
+                         section 4.2.1.",
                     ),
             );
             return Err(());

--- a/src/vhdl/syntax/lexer/bundler.rs
+++ b/src/vhdl/syntax/lexer/bundler.rs
@@ -111,8 +111,8 @@ where
                         DiagBuilder2::error("String literal must not contain line breaks.")
                             .span(sp.end())
                             .add_note(
-                                "Use string concatenation (e.g. \"abc\" & \
-                                \"def\") to break strings across lines",
+                                "Use string concatenation (e.g. \"abc\" & \"def\") to break \
+                                 strings across lines",
                             ),
                     );
                 } else {

--- a/src/vhdl/syntax/parser/core.rs
+++ b/src/vhdl/syntax/parser/core.rs
@@ -148,8 +148,8 @@ pub fn recover<P: Parser>(p: &mut P, term: &[Token], eat_term: bool) {
                     if open != x {
                         p.emit(
                             DiagBuilder2::fatal(format!(
-                                "Found closing {} which is not the \
-                                complement to the previous opening {}",
+                                "Found closing {} which is not the complement to the previous \
+                                 opening {}",
                                 CloseDelim(x),
                                 OpenDelim(open)
                             ))

--- a/src/vhdl/syntax/parser/rules.rs
+++ b/src/vhdl/syntax/parser/rules.rs
@@ -308,8 +308,8 @@ pub fn parse_name_suffix<P: Parser>(
                     let Spanned { value: wrong, span } = p.peek(0);
                     p.emit(
                         DiagBuilder2::error(
-                            "Expected identifier, character \
-                            literal, operator symbol, or `all` after `.`",
+                            "Expected identifier, character literal, operator symbol, or `all` \
+                             after `.`",
                         )
                         .span(span)
                         .add_note("see IEEE 1076-2008 section 8.3"),
@@ -691,13 +691,13 @@ pub fn parse_intf_decl<P: Parser>(
                     DiagBuilder2::error("Expected an interface declaration")
                         .span(span)
                         .add_note(
-                            "`constant`, `signal`, `variable`, and \
-                            `file` start an object declaration",
+                            "`constant`, `signal`, `variable`, and `file` start an object \
+                             declaration",
                         )
                         .add_note("`type` starts a type declaration")
                         .add_note(
-                            "`procedure`, `function`, `pure function`, or `impure \
-                            function` start a subprogram declaration",
+                            "`procedure`, `function`, `pure function`, or `impure function` start \
+                             a subprogram declaration",
                         )
                         .add_note("`package` starts a package declaration")
                         .add_note("see IEEE 1076-2008 section 6.5"),
@@ -1026,8 +1026,8 @@ pub fn parse_paren_elem_vec<P: Parser>(p: &mut P) -> ReportedResult<Vec<ast::Par
                     DiagBuilder2::error("Superfluous additional expressions")
                         .span(span)
                         .add_note(
-                            "If you wanted an association list, did you \
-                            forget a `=>` after the list of choices?",
+                            "If you wanted an association list, did you forget a `=>` after the \
+                             list of choices?",
                         ),
                 );
                 return Err(Reported);
@@ -1161,10 +1161,9 @@ pub fn parse_primary_expr<P: Parser>(p: &mut P) -> ReportedResult<ast::Expr> {
         ))
         .span(q)
         .add_note(
-            "A primary expression is either an abstract, \
-            bit string, character, or string literal; a name; \
-            a parenthesized expression `( ... )`; an allocation \
-            `new ...`; or the constants `null`, `open`, or `others`.",
+            "A primary expression is either an abstract, bit string, character, or string \
+             literal; a name; a parenthesized expression `( ... )`; an allocation `new ...`; or \
+             the constants `null`, `open`, or `others`.",
         ),
     );
     Err(Reported)
@@ -1202,8 +1201,8 @@ pub fn try_name_or_qualified_primary_expr<P: Parser>(
                     DiagBuilder2::error("Expected a parenthesized expression after `'`")
                         .span(q)
                         .add_note(
-                            "`'` introduces a qualified expression, \
-                            which is of the form `<name>'(<expr>)`",
+                            "`'` introduces a qualified expression, which is of the form \
+                             `<name>'(<expr>)`",
                         )
                         .add_note("see IEEE 1076-2008 section 9.3.5"),
                 );
@@ -1713,14 +1712,13 @@ pub fn parse_alias_decl<P: Parser>(p: &mut P) -> ReportedResult<ast::AliasDecl> 
             let pk = p.peek(0);
             p.emit(
                 DiagBuilder2::error(format!(
-                    "Expected alias designator after \
-                    keyword `alias`, found {} instead",
+                    "Expected alias designator after keyword `alias`, found {} instead",
                     pk.value
                 ))
                 .span(pk.span)
                 .add_note(
-                    "An alias designator is either an identifier, \
-                    a character literal, or an operator symbol",
+                    "An alias designator is either an identifier, a character literal, or an \
+                     operator symbol",
                 )
                 .add_note("see IEEE 1076-2008 section 6.6"),
             );
@@ -2251,8 +2249,8 @@ pub fn parse_block_comp_spec<P: Parser>(p: &mut P) -> ReportedResult<Spanned<ast
                 let sp = p.peek(0).span;
                 p.emit(
                     DiagBuilder2::error(format!(
-                        "Expected block name, component label, \
-                        `all`, or `others`, found {} instead",
+                        "Expected block name, component label, `all`, or `others`, found {} \
+                         instead",
                         wrong
                     ))
                     .span(sp),
@@ -2426,12 +2424,10 @@ pub fn parse_entity_class<P: Parser>(p: &mut P) -> ReportedResult<ast::EntityCla
                 DiagBuilder2::error(format!("Expected entity class, found {} instead", wrong))
                     .span(pk.span)
                     .add_note(
-                        "An entity class is any of the keywords \
-                        `architecture`, `component`, `configuration`, \
-                        `constant`, `entity`, `file`, `function`, `group`, \
-                        `label`, `literal`, `package`, `procedure`, `property`, \
-                        `sequence`, `signal`, `subtype`, `type`, `units`, or \
-                        `variable`",
+                        "An entity class is any of the keywords `architecture`, `component`, \
+                         `configuration`, `constant`, `entity`, `file`, `function`, `group`, \
+                         `label`, `literal`, `package`, `procedure`, `property`, `sequence`, \
+                         `signal`, `subtype`, `type`, `units`, or `variable`",
                     )
                     .add_note("see IEEE 1076-2008 section 7.2"),
             );
@@ -3126,8 +3122,8 @@ where
         let pk = p.peek(0);
         p.emit(
             DiagBuilder2::error(format!(
-                "`begin` is required before {}, to separate \
-                it from the preceding declarative items",
+                "`begin` is required before {}, to separate it from the preceding declarative \
+                 items",
                 pk.value
             ))
             .span(pk.span),

--- a/src/vhdl/term.rs
+++ b/src/vhdl/term.rs
@@ -1197,8 +1197,12 @@ where
                     DiagBuilder2::error(format!(
                         "`{}` is not a valid constraint",
                         term.span.extract()
-                    )).span(term.span)
-                        .add_note("Did you mean a range constraint (`range ...`) or an array or record constraint (`(...)`)? See IEEE 1076-2008 section 6.3."),
+                    ))
+                    .span(term.span)
+                    .add_note(
+                        "Did you mean a range constraint (`range ...`) or an array or record \
+                         constraint (`(...)`)? See IEEE 1076-2008 section 6.3.",
+                    ),
                 );
                 debugln!("It is a {:#?}", term);
                 return Err(());
@@ -1261,8 +1265,12 @@ where
                         DiagBuilder2::error(format!(
                             "`{}` is not a valid constraint for a record element",
                             term.span.extract()
-                        )).span(term.span)
-                            .add_note("Element constraints must be of the form `name (constraint)`. See IEEE 1076-2008 section 5.3.3."),
+                        ))
+                        .span(term.span)
+                        .add_note(
+                            "Element constraints must be of the form `name (constraint)`. See \
+                             IEEE 1076-2008 section 5.3.3.",
+                        ),
                     );
                     debugln!("It is a {:#?}", term.value);
                     has_fails = true;
@@ -1332,8 +1340,12 @@ where
                         DiagBuilder2::error(format!(
                             "`{}` is not a valid element constraint",
                             con.span.extract()
-                        )).span(con.span)
-                            .add_note("Did you mean an array or record constraint (`(...)`)? See IEEE 1076-2008 section 6.3."),
+                        ))
+                        .span(con.span)
+                        .add_note(
+                            "Did you mean an array or record constraint (`(...)`)? See IEEE \
+                             1076-2008 section 6.3.",
+                        ),
                     );
                     debugln!("It is a {:#?}", con);
                     return Err(());
@@ -1597,8 +1609,12 @@ where
                     DiagBuilder2::error(format!(
                         "aggregate element `{}` appears after `others`",
                         field.span.extract()
-                    )).span(field.span)
-                        .add_note("The `others` element must be the last in an aggregate. See IEEE 1076-2008 section 9.3.3.1."),
+                    ))
+                    .span(field.span)
+                    .add_note(
+                        "The `others` element must be the last in an aggregate. See IEEE \
+                         1076-2008 section 9.3.3.1.",
+                    ),
                 );
                 return Err(());
             }
@@ -1608,10 +1624,12 @@ where
                 if mode > Mode::Positional {
                     self.emit(
                         DiagBuilder2::error(format!(
-                            "positional element `{}` must appear before all named elements in aggregate",
+                            "positional element `{}` must appear before all named elements in \
+                             aggregate",
                             field.value.1.span.extract()
-                        )).span(field.value.1.span)
-                            .add_note("See IEEE 1076-2008 section 9.3.3.1."),
+                        ))
+                        .span(field.value.1.span)
+                        .add_note("See IEEE 1076-2008 section 9.3.3.1."),
                     );
                     return Err(());
                 }
@@ -1646,86 +1664,104 @@ where
             .iter()
             .any(|n| n.value.0.iter().any(|c| c.value.is_element()))
         {
-            hir::AggregateKind::Record(named
-                .into_iter()
-                .map(
-                    |Spanned {
-                         value: (choices, expr),
-                         span,
-                     }| {
-                        let choices = choices
-                            .into_iter()
-                            .map(
-                                |Spanned {
-                                     value: choice,
-                                     span,
-                                 }| {
-                                    let choice = match choice {
-                                        hir::Choice::Element(n) => n,
-                                        _ => {
-                                            self.emit(
-                                                DiagBuilder2::error(format!(
-                                                    "choice `{}` is not a record element",
-                                                    span.extract()
-                                                )).span(span)
-                                                    .add_note("An aggregate must either be a record or array aggregate. It cannot contain both record elements and array elements. See IEEE 1076-2008 section 9.3.3.1."),
-                                            );
-                                            return Err(());
-                                        }
-                                    };
-                                    Ok(Spanned::new(choice, span))
-                                },
-                            )
-                            .collect::<Vec<Result<_>>>()
-                            .into_iter()
-                            .collect::<Result<Vec<_>>>()?;
-                        Ok(Spanned::new((choices, expr), span))
-                    },
-                )
-                .collect::<Vec<Result<_>>>()
-                .into_iter()
-                .collect::<Result<Vec<_>>>()?)
+            hir::AggregateKind::Record(
+                named
+                    .into_iter()
+                    .map(
+                        |Spanned {
+                             value: (choices, expr),
+                             span,
+                         }| {
+                            let choices = choices
+                                .into_iter()
+                                .map(
+                                    |Spanned {
+                                         value: choice,
+                                         span,
+                                     }| {
+                                        let choice = match choice {
+                                            hir::Choice::Element(n) => n,
+                                            _ => {
+                                                self.emit(
+                                                    DiagBuilder2::error(format!(
+                                                        "choice `{}` is not a record element",
+                                                        span.extract()
+                                                    ))
+                                                    .span(span)
+                                                    .add_note(
+                                                        "An aggregate must either be a record or \
+                                                         array aggregate. It cannot contain both \
+                                                         record elements and array elements. See \
+                                                         IEEE 1076-2008 section 9.3.3.1.",
+                                                    ),
+                                                );
+                                                return Err(());
+                                            }
+                                        };
+                                        Ok(Spanned::new(choice, span))
+                                    },
+                                )
+                                .collect::<Vec<Result<_>>>()
+                                .into_iter()
+                                .collect::<Result<Vec<_>>>()?;
+                            Ok(Spanned::new((choices, expr), span))
+                        },
+                    )
+                    .collect::<Vec<Result<_>>>()
+                    .into_iter()
+                    .collect::<Result<Vec<_>>>()?,
+            )
         } else {
-            hir::AggregateKind::Array(named
-                .into_iter()
-                .map(
-                    |Spanned {
-                         value: (choices, expr),
-                         span,
-                     }| {
-                        let choices = choices
-                            .into_iter()
-                            .map(
-                                |Spanned {
-                                     value: choice,
-                                     span,
-                                 }| {
-                                    let choice = match choice {
-                                        hir::Choice::Expr(e) => hir::ArrayChoice::Expr(e),
-                                        hir::Choice::DiscreteRange(e) => hir::ArrayChoice::DiscreteRange(e),
-                                        _ => {
-                                            self.emit(
-                                                DiagBuilder2::error(format!(
-                                                    "choice `{}` is not an array element",
-                                                    span.extract()
-                                                )).span(span)
-                                                    .add_note("An aggregate must either be a record or array aggregate. It cannot contain both record elements and array elements. See IEEE 1076-2008 section 9.3.3.1."),
-                                            );
-                                            return Err(());
-                                        }
-                                    };
-                                    Ok(Spanned::new(choice, span))
-                                },
-                            )
-                            .collect::<Vec<Result<_>>>()
-                            .into_iter()
-                            .collect::<Result<Vec<_>>>()?;
-                        Ok(Spanned::new((choices, expr), span))
-                    },
-                )
-                .collect::<Vec<Result<_>>>()
-                .into_iter()
-                .collect::<Result<Vec<_>>>()?)
+            hir::AggregateKind::Array(
+                named
+                    .into_iter()
+                    .map(
+                        |Spanned {
+                             value: (choices, expr),
+                             span,
+                         }| {
+                            let choices = choices
+                                .into_iter()
+                                .map(
+                                    |Spanned {
+                                         value: choice,
+                                         span,
+                                     }| {
+                                        let choice = match choice {
+                                            hir::Choice::Expr(e) => hir::ArrayChoice::Expr(e),
+                                            hir::Choice::DiscreteRange(e) => {
+                                                hir::ArrayChoice::DiscreteRange(e)
+                                            }
+                                            _ => {
+                                                self.emit(
+                                                    DiagBuilder2::error(format!(
+                                                        "choice `{}` is not an array element",
+                                                        span.extract()
+                                                    ))
+                                                    .span(span)
+                                                    .add_note(
+                                                        "An aggregate must either be a record or \
+                                                         array aggregate. It cannot contain both \
+                                                         record elements and array elements. See \
+                                                         IEEE 1076-2008 section 9.3.3.1.",
+                                                    ),
+                                                );
+                                                return Err(());
+                                            }
+                                        };
+                                        Ok(Spanned::new(choice, span))
+                                    },
+                                )
+                                .collect::<Vec<Result<_>>>()
+                                .into_iter()
+                                .collect::<Result<Vec<_>>>()?;
+                            Ok(Spanned::new((choices, expr), span))
+                        },
+                    )
+                    .collect::<Vec<Result<_>>>()
+                    .into_iter()
+                    .collect::<Result<Vec<_>>>()?,
+            )
         };
 
         let hir = hir::Aggregate {
@@ -1763,7 +1799,13 @@ where
                     .into_iter()
                     .map(|(formal, actual)| {
                         if formal.len() != 1 {
-                            self.emit(DiagBuilder2::error("formal part of association element must be exactly one expression").span(term_span));
+                            self.emit(
+                                DiagBuilder2::error(
+                                    "formal part of association element must be exactly one \
+                                     expression",
+                                )
+                                .span(term_span),
+                            );
                             return Err(());
                         }
                         let formal = formal.into_iter().next().unwrap();
@@ -1785,8 +1827,9 @@ where
                         DiagBuilder2::error(format!(
                             "`{}` is not a valid association list",
                             term.span.extract()
-                        )).span(term.span)
-                            .add_note("See IEEE 1076-2008 section 6.5.7."),
+                        ))
+                        .span(term.span)
+                        .add_note("See IEEE 1076-2008 section 6.5.7."),
                     );
                     debugln!("It is a {:#?}", term);
                     return Err(());

--- a/src/vhdl/typeck.rs
+++ b/src/vhdl/typeck.rs
@@ -512,8 +512,8 @@ impl<'sbc, 'lazy, 'sb, 'ast, 'ctx> TypeckContext<'sbc, 'lazy, 'sb, 'ast, 'ctx> {
                         DiagBuilder2::error(format!("`{}` is not a subrange of `{}`", subty, ty))
                             .span(span)
                             .add_note(
-                                "The range of a subtype must be entirely \
-                                contained within the range of the target type.",
+                                "The range of a subtype must be entirely contained within the \
+                                 range of the target type.",
                             ), // TODO: Add reference to standard.
                     );
                 }


### PR DESCRIPTION
rustfmt does not format strings by default and may prevent whole blocks from being formatted.

Long strings (and blocks containing them) have been formatted with:
```
cargo fmt -- --config format_strings=true
```