### PR TITLE
svlog: fix drive strength parsing

### DIFF
--- a/src/svlog/syntax/parser.rs
+++ b/src/svlog/syntax/parser.rs
@@ -5180,6 +5180,7 @@ fn try_drive_strength<'n>(
         p.bump();
         p.require_reported(Comma)?;
         if let Some(b) = as_drive_strength(p.peek(0).0) {
+            p.bump();
             Ok(Some((a, b)))
         } else {
             let q = p.peek(0).1;

--- a/test/svlog/parser/drive_strength.sv
+++ b/test/svlog/parser/drive_strength.sv
@@ -1,0 +1,10 @@
+// RUN: moore %s -e foo -O0
+module foo;
+    wire (highz1, pull0) bar;
+endmodule
+
+// CHECK: entity @foo () -> () {
+// CHECK:     %0 = const i1 0
+// CHECK:     %bar = sig i1 %0
+// CHECK:     halt
+// CHECK: }


### PR DESCRIPTION
Drive strength parsing was not bumping parser after first strength is parsed.

This should improve sv-tests [1], there are 24 tests failing there directly related to this.

I couldn't find where on testing to add a check for this, please let me know if you want a test case for it.

https://symbiflow.github.io/sv-tests/#moore_parse|10.3.4|cont_assignment_strength_highz1_pull0

<img width="774" alt="Screen Shot 2020-07-17 at 00 39 35" src="https://user-images.githubusercontent.com/1095/87746075-0932d600-c7c6-11ea-9926-9e29a117a667.png">
