### PR TITLE
svlog: Forward declaration syntax support

### DIFF
--- a/src/svlog/hir/lowering.rs
+++ b/src/svlog/hir/lowering.rs
@@ -836,6 +836,7 @@ fn lower_type<'gcx>(
         | ast::RealType
         | ast::RealtimeType
         | ast::SpecializedType(..)
+        | ast::ForwardType { .. }
         | ast::ScopedType { .. } => {
             error!("{:#?}", ty);
             bug_span!(

--- a/src/svlog/resolver.rs
+++ b/src/svlog/resolver.rs
@@ -755,6 +755,18 @@ impl<'a, 'c, C: Context<'a>> ScopeGenerator<'a, 'c, C> {
                 }
             };
 
+            // We can also have multiple forward declarations of the same name, must
+            // ignore all but the first one here. This also correctly handles the case
+            // where a "forward" declaration actually comes after the definition, which
+            // is apparently not an error in svlog.
+            if let DefNode::Ast(node) = def.node {
+                if let ast::AllNode::Typedef(ast) = node.as_all() {
+                    if let ast::ForwardType { kind: _ } = ast.ty.kind.data {
+                        return;
+                    }
+                }
+            }
+
             if !def.may_override {
                 let d = DiagBuilder2::error(format!("`{}` is defined multiple times", def.name))
                     .span(def.name.span)

--- a/src/svlog/syntax/ast.rs
+++ b/src/svlog/syntax/ast.rs
@@ -762,7 +762,7 @@ pub enum TypeKind<'a> {
 
     // Forward declarations
     ForwardType {
-        kind: Box<TypeKind<'a>>
+        kind: Box<TypeKind<'a>>,
     },
 
     // Integer Vector Types

--- a/src/svlog/syntax/ast.rs
+++ b/src/svlog/syntax/ast.rs
@@ -760,6 +760,11 @@ pub enum TypeKind<'a> {
         name: Spanned<Name>,
     },
 
+    // Forward declarations
+    ForwardType {
+        kind: Box<TypeKind<'a>>
+    },
+
     // Integer Vector Types
     BitType,
     LogicType,

--- a/src/svlog/syntax/parser.rs
+++ b/src/svlog/syntax/parser.rs
@@ -1802,12 +1802,12 @@ fn parse_struct_type<'n>(p: &mut dyn AbstractParser<'n>) -> ReportedResult<TypeK
                 kind: kind,
                 packed: packed,
                 signing: signing,
-                members: Vec::default()
+                members: Vec::default(),
             },
         ));
 
         let forward_type = ast::ForwardType {
-            kind: Box::new(TypeKind::new(span, struct_type))
+            kind: Box::new(TypeKind::new(span, struct_type)),
         };
 
         Ok(forward_type)
@@ -5043,13 +5043,19 @@ fn parse_typedef<'n>(p: &mut dyn AbstractParser<'n>) -> ReportedResult<Typedef<'
             span.expand(p.last_span());
 
             let dims = Vec::default();
-            let ty = Type::new(span, TypeData {
-                kind: TypeKind::new(span, ast::ForwardType {
-                    kind: Box::new(TypeKind::new(span, ImplicitType))
-                }),
-                sign: TypeSign::None,
-                dims: Vec::default()
-            });
+            let ty = Type::new(
+                span,
+                TypeData {
+                    kind: TypeKind::new(
+                        span,
+                        ast::ForwardType {
+                            kind: Box::new(TypeKind::new(span, ImplicitType)),
+                        },
+                    ),
+                    sign: TypeSign::None,
+                    dims: Vec::default(),
+                },
+            );
             return Ok(Typedef::new(span, TypedefData { name, ty, dims }));
         }
     }
@@ -5059,7 +5065,14 @@ fn parse_typedef<'n>(p: &mut dyn AbstractParser<'n>) -> ReportedResult<Typedef<'
     let (dims, _) = parse_optional_dimensions(p)?;
     p.require_reported(Semicolon)?;
     span.expand(p.last_span());
-    Ok(Typedef::new(span, TypedefData { name: ident_name, ty: ty, dims: dims }))
+    Ok(Typedef::new(
+        span,
+        TypedefData {
+            name: ident_name,
+            ty: ty,
+            dims: dims,
+        },
+    ))
 }
 
 fn parse_port_decl<'n>(p: &mut dyn AbstractParser<'n>) -> ReportedResult<PortDecl<'n>> {

--- a/src/svlog/syntax/parser.rs
+++ b/src/svlog/syntax/parser.rs
@@ -5029,9 +5029,13 @@ fn parse_typedef<'n>(p: &mut dyn AbstractParser<'n>) -> ReportedResult<Typedef<'
     p.require_reported(Keyword(Kw::Typedef))?;
 
     // We might be a declaration of the format "typedef x;", in which case we
-    // just store what we know and continue.
+    // just store what we know and continue. Also handle "typedef enum x;" syntax
+    // here to avoid the enum parsing code, which has to deal with type specifers.
     {
         let mut bp = BranchParser::new(p);
+        if bp.peek(0).0 == Keyword(Kw::Enum) {
+            bp.bump();
+        }
         let name = parse_identifier_name(&mut bp, "type name");
         let semi = bp.require_reported(Semicolon);
         if let (Ok(name), Ok(semi)) = (name, semi) {

--- a/src/svlog/typeck.rs
+++ b/src/svlog/typeck.rs
@@ -670,6 +670,13 @@ pub(crate) fn packed_type_from_ast<'a>(
             packed_type_from_def(cx, def, name.span, env)
         }
 
+        // Forward declarations
+        ast::ForwardType { kind: _ } => {
+            // TODO This should likely be a nicer error if we get here because a forward
+            // declaration is not later defined.
+            bug_span!(ast.span(), cx, "type {:#1?} not implemented", ast.kind)
+        }
+
         // Scoped types
         ast::ScopedType {
             ref ty,


### PR DESCRIPTION
Resolves #201 in a more complete way than the experiment I wrote in that issue.

Fixes (at least) the following currently failing tests from sv-tests:
https://symbiflow.github.io/sv-tests/#moore|6.18|typedef_test_0
https://symbiflow.github.io/sv-tests/#moore|6.18|typedef_test_22
https://symbiflow.github.io/sv-tests/#moore|7.2|struct_test_0
https://symbiflow.github.io/sv-tests/#moore|7.3|union_test_0

In general, this PR parses typedefs of the following forms:
* `typedef x;`
* `typedef (struct|enum|union|union tagged) x;`

These typedefs can occur multiple times for the same name 'x', and in the sv-tests examples, can appear both before and after the typedef that completely defines the type. The changes to the resolver handle these cases and ensure that
1. A complete definition will override a forward declaration, but not the other way around.
2. Two complete definitions of the same type name will still produce a compiler error.
3. Multiple forward declarations for the same type name may be present without raising errors.

Error cases not yet handled:
* Conflicting types in forward declarations, i.e. code of the form `typedef struct x;` followed by a definition `typedef int x;` I think the information now present in the AST to resolve these for the struct/union cases but it doesn't yet check.
* Compiler does not error if there is a forward declaration without a corresponding definition. Is there a complete typecheck pass to hook into that happens after parsing? I wrote the code such that if a definition of TypeKind `ForwardType` is present after the resolver runs, that should indicate this error condition.  Generating this error is tested by (http://192.168.200.4:4444/#moore|6.18|typedef_test_28).
