### PR TITLE
Fix bug with port decl outside of module params not parsing correctly

### DIFF
--- a/src/svlog/typeck.rs
+++ b/src/svlog/typeck.rs
@@ -217,7 +217,6 @@ pub(crate) fn type_of_port_decl<'a>(
     type_of_varlike(cx, ast_decl, &ast_decl.ty, ast, &ast.dims, env)
 }
 
-
 /// Determine the type of a variable declaration.
 #[moore_derive::query]
 pub(crate) fn type_of_var_decl<'a>(

--- a/src/svlog/typeck.rs
+++ b/src/svlog/typeck.rs
@@ -59,6 +59,7 @@ pub(crate) fn type_of<'a>(
             ast::AllNode::VarDecl(..) => return Ok(cx.type_of_var_decl(Ref(name), env)),
             ast::AllNode::NetDecl(..) => return Ok(cx.type_of_net_decl(Ref(name), env)),
             ast::AllNode::StructMember(..) => return Ok(cx.type_of_struct_member(Ref(name), env)),
+            ast::AllNode::PortDecl(..) => return Ok(cx.type_of_port_decl(Ref(name), env)),
             x => bug_span!(ast.span(), cx, "VarDeclName with weird parent {:?}", x),
         },
         ast::AllNode::ParamValueDecl(x) => return Ok(cx.type_of_value_param(Ref(x), env)),
@@ -199,6 +200,23 @@ pub(crate) fn type_of_ext_port<'a>(
         );
     }
 }
+
+/// Determine the type of a port declaration.
+#[moore_derive::query]
+pub(crate) fn type_of_port_decl<'a>(
+    cx: &impl Context<'a>,
+    Ref(ast): Ref<'a, ast::VarDeclName<'a>>,
+    env: ParamEnv,
+) -> &'a UnpackedType<'a> {
+    let ast_decl = ast
+        .get_parent()
+        .unwrap()
+        .as_all()
+        .get_port_decl()
+        .expect("parent not a PortDecl");
+    type_of_varlike(cx, ast_decl, &ast_decl.ty, ast, &ast.dims, env)
+}
+
 
 /// Determine the type of a variable declaration.
 #[moore_derive::query]

--- a/test/svlog/modules/port_decl_after_module.sv
+++ b/test/svlog/modules/port_decl_after_module.sv
@@ -1,0 +1,13 @@
+module port_decl_after_module_dff(clk, reset, d, q);
+    input clk;
+    input reset;
+    input d;
+    output reg q;
+
+    always_ff @(posedge clk or posedge reset) begin
+        if (reset)
+            q <= 1'b0;
+        else
+            q <= d;
+    end
+endmodule


### PR DESCRIPTION
Fixes #218. I'm not sure if this is the correct fix, but I re-created the test in the `test` directory and it seems to parse unlike before.