### PR TITLE
Surround moore.mir.concat with conversion casts to pass values of the type the ops expect

### DIFF
--- a/src/circt/src/moore.rs
+++ b/src/circt/src/moore.rs
@@ -32,6 +32,11 @@ pub fn dialect() -> DialectHandle {
     DialectHandle::from_raw(unsafe { mlirGetDialectHandle__moore__() })
 }
 
+/// Check if the type is a simple bitvector type.
+pub fn is_simple_bitvector_type(ty: Type) -> bool {
+    unsafe { mooreIsSimpleBitVectorType(ty.raw()) }
+}
+
 /// Get the size of a simple bit-vector in bits.
 pub fn get_simple_bitvector_size(ty: Type) -> usize {
     assert!(unsafe { mooreIsSimpleBitVectorType(ty.raw()) });

--- a/test/mlir/expressions.sv
+++ b/test/mlir/expressions.sv
@@ -16,8 +16,7 @@ endfunction
 // CHECK-LABEL: func @Concat(
 // CHECK-SAME: [[X:%.+]]: i4, [[Y:%.+]]: i2, [[Z:%.+]]: i1) -> i7 {
 function bit [6:0] Concat(bit [3:0] x, bit [1:0] y, bit z);
-    // CHECK-NEXT: [[TMP:%.+]] = moore.mir.concat [[X]], [[Y]], [[Z]]
-    // CHECK-NEXT: return [[TMP]]
+    // CHECK: moore.mir.concat %{{.+}}, %{{.+}}, %{{.+}} : (!moore.packed<range<bit, 3:0>>, !moore.packed<range<bit, 1:0>>, !moore.packed<range<bit, 0:0>>) -> !moore.packed<range<bit, 6:0>>
     return {x, y, z};
 endfunction
 


### PR DESCRIPTION
This should fix (most of) CI.

Once we add even more operations, we should do some kind of lazy conversion cast insertion instead if eagerly surrounding every op.