### PR TITLE
Add C++17 flag in build.rs of circt-sys to avoid compilation error on MAC

### DIFF
--- a/src/circt-sys/build.rs
+++ b/src/circt-sys/build.rs
@@ -185,6 +185,7 @@ fn main() {
     cc::Build::new()
         .cpp(true)
         .file("wrapper.cpp")
+        .flag("-std=c++17")
         .includes(&include_dirs)
         .warnings(false)
         .extra_warnings(false)


### PR DESCRIPTION
* Add `-std=c++17` flag to `src/circt-sys/build.rs`.
* Now everything compiles successfully on MacOS Ventura.